### PR TITLE
xdelta3-dir-patcher: fixed an error when calculating the relative path

### DIFF
--- a/xdelta3-dir-patcher.py
+++ b/xdelta3-dir-patcher.py
@@ -73,7 +73,7 @@ class XDelta3DirPatcher(object):
         delta_target_dir = path.join(target_dir, 'xdelta')
 
         for root, dirs, new_files in walk(new_dir):
-            rel_path = path.relpath(root, new_dir).split(sep)[0]
+            rel_path = path.relpath(root, new_dir)
 
             print('-'*10, root, '-'*10)
             print(new_files)


### PR DESCRIPTION
I've got an error when running the xdelta3-dir-patcher over the two version of com.endlessm.endless-weather available on the staging server.

Significative part of the error log:
('----------', 'com.endlessm.endless-weather-v2/share', '----------')
[]('----------',)
[]('----------',)
['com.endlessm.endless-weather.service']

Processing com.endlessm.endless-weather.service
['com.endlessm.endless-weather-v1/share/com.endlessm.endless-weather.service', 'com.endlessm.endless-weather-v2/share/com.endlessm.endless-weather.service', 'patches/xdelta/share/com.endlessm.endless-weather.service']
Old file not present. Ignoring source in XDelta
Generating xdelta: ['xdelta3', '-f', '-e', 'com.endlessm.endless-weather-v2/share/com.endlessm.endless-weather.service', 'patches/xdelta/share/com.endlessm.endless-weather.service']
xdelta3: file open failed: read: com.endlessm.endless-weather-v2/share/com.endlessm.endless-weather.service: No such file or directory
Copying mode data

Looks like the error was in the way we calculated the relative path.
Making a pull request to fix it.

This is related to https://github.com/endlessm/eos-shell/issues/2711
