### PR TITLE
AppUpdater: Added a fix for xdelta3 packaging to make it work on Debian as well

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xdelta3-dir-patcher (0.2-1) unstable; urgency=medium
+
+  * Made the package be installable on Debian (bad dh_python3 dep generation).
+
+ -- Srdjan Grubor <sgnn7@sgnn7.org>  Mon, 8 Dec 2014 14:18:13 -0500
+
 xdelta3-dir-patcher (0.2) unstable; urgency=medium
 
   * Fixed problems with creation of target directories

--- a/debian/rules
+++ b/debian/rules
@@ -2,3 +2,7 @@
 
 %:
 	dh $@ --with python3
+
+# Use hardcoded 3.2 since Ubuntu shoves (>=3.2~) version, making Debian break
+override_dh_python3:
+	dh_python3 -V 3.2


### PR DESCRIPTION
Ubuntu dh_python3 added a strange tilda in 3.2 version dependencies,
making installations on Debian break since those have 3.2.x pattern.

[endlessm/eos-shell#2654]
