### PR TITLE
App Updates: Fixed problems with applications of delta chown and ingore_euid flag set

### DIFF
--- a/xdelta3-dir-patcher
+++ b/xdelta3-dir-patcher
@@ -843,7 +843,12 @@ class XDelta3DirPatcher(object):
             chmod(target, file_obj.permissions)
 
         if file_obj.uid and file_obj.gid:
-            lchown(target, file_obj.uid, file_obj.gid)
+            try:
+                lchown(target, file_obj.uid, file_obj.gid)
+            except PermissionError as pe:
+                # We only ignore problems here if ignore_euid flag is set
+                if not self.args.ignore_euid:
+                    raise pe
 
     def _find_file_delta(self, filename, old_archive_obj, new_archive_obj,
                          old_root,


### PR DESCRIPTION
On limited accounts, we can't chown things so doing that on the target
files was failing fatally.

[endlessm/eos-shell#5064]