### PR TITLE
Xdelta: Fixed issues where some Tar archives would have dirs appended with '/'

### DIFF
--- a/tests/test_xdelta3_dir_patcher.py
+++ b/tests/test_xdelta3_dir_patcher.py
@@ -341,7 +341,7 @@ class TestXDelta3DirPatcher(unittest.TestCase):
     def test_version_is_correct(self):
         output = TestHelpers.check_output2(["./%s" % self.EXECUTABLE,
                                             '--version'])
-        self.assertEqual(output, "%s v0.6.1\n" % self.EXECUTABLE)
+        self.assertEqual(output, "%s v0.6.3\n" % self.EXECUTABLE)
 
     def test_help_is_available(self):
         self.assertIsNotNone(TestHelpers.check_output2(["./%s" % self.EXECUTABLE,

--- a/xdelta3-dir-patcher
+++ b/xdelta3-dir-patcher
@@ -48,7 +48,7 @@ from tempfile import mkdtemp
 
 from os import open as os_open #Prevent mangling the regular open()
 
-VERSION='0.6.2'
+VERSION='0.6.3'
 
 # Allows for invoking attributes as methods/functions
 class AttributeDict(dict):
@@ -502,7 +502,7 @@ class XDelta3TarImpl(XDelta3AbstractArchiveImpl):
         files = []
         for member in members:
             if member.isdir():
-                folders.append((member.name, member))
+                folders.append((member.name.rstrip(path.sep), member))
             else:
                 files.append((member.name, member))
 
@@ -548,7 +548,7 @@ class XDelta3TarImpl(XDelta3AbstractArchiveImpl):
         ordered_items = OrderedDict()
         ordered_items[None] = items[None]
         for item in members:
-            ordered_items[item.name] = items.pop(item.name)
+            ordered_items[item.name] = items.pop(item.name.rstrip(path.sep))
 
         # Add back any items that we manually created (missing hierarchy)
         ordered_items.update(items)


### PR DESCRIPTION
We would hit errors when we encountered '/' at the end of directories
so this fix ensures that we match exactly on those.

[endlessm/eos-shell#6334]