### PR TITLE
Handle makedirs EEXIST handling on python < 3.4.1

### DIFF
--- a/xdelta3-dir-patcher
+++ b/xdelta3-dir-patcher
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 #
 #    xdelta3-dir-patcher
-#    Copyright (C) 2014-2015 Endless Mobile
+#    Copyright (C) 2014-2016 Endless Mobile
 #
 #   This library is free software; you can redistribute it and/or
 #   modify it under the terms of the GNU Lesser General Public
@@ -20,6 +20,7 @@
 #   USA
 
 import argparse
+import errno
 import logging
 import operator
 import random
@@ -36,19 +37,37 @@ from filecmp import dircmp
 from grp import getgrgid
 from io import StringIO
 from multiprocessing import cpu_count
-from os import chmod, lchown, geteuid, listdir, lstat, makedirs, mkdir
+from os import chmod, lchown, geteuid, listdir, lstat, mkdir
 from os import O_NOFOLLOW, O_RDONLY, path, readlink, remove, rmdir, symlink, sep
 from os import stat, utime, walk
 from pwd import getpwuid
 from shutil import copymode, copystat, copyfile, copytree, copy2, rmtree
 from stat import *
 from subprocess import check_output, STDOUT, CalledProcessError
-from sys import stderr, stdout
+from sys import hexversion, stderr, stdout
 from tempfile import mkdtemp
 
 from os import open as os_open #Prevent mangling the regular open()
+from os import makedirs as os_makedirs
 
 VERSION='0.6.3'
+
+if hexversion < 0x30401f0:
+    # Handle makedirs throwing EEXIST if the leaf directory mode doesn't
+    # match on python < 3.4.1
+    def makedirs(*args, **kwargs):
+        """Wrapper around os.makedirs on python < 3.4.1 to ignore EEXIST when
+        exist_ok=True.
+        """
+        exist_ok = kwargs.get('exist_ok', False)
+        try:
+            os_makedirs(*args, **kwargs)
+        except OSError as err:
+            if not exist_ok or err.errno != errno.EEXIST:
+                raise
+else:
+    # Use regular os.makedirs
+    makedirs = os_makedirs
 
 # Allows for invoking attributes as methods/functions
 class AttributeDict(dict):


### PR DESCRIPTION
Before python 3.4.1, if os.makedirs was called with exist_ok=True and
the leaf directory existed without the expected mode, EEXIST would be
raised. We want the 3.4.1+ behavior where an existing directory is fine
no matter what mode it has. See
https://docs.python.org/3/library/os.html#os.makedirs for details.

Add a wrapper on python < 3.4.1 that always ignores EEXIST if
exist_ok=True.

[endlessm/eos-shell#6373]